### PR TITLE
Added missing slash in commands search pattern

### DIFF
--- a/SVN.php
+++ b/SVN.php
@@ -299,7 +299,7 @@ class VersionControl_SVN
             if (is_file($entry)
                 && is_readable($entry)
             ) {
-                $commands[] = basename($entry, '.php');
+                $commands[] = strtolower(basename($entry, '.php'));
             }
         }
 


### PR DESCRIPTION
Without slash it throws fatal error while trying to find **ALL** commands by wrong path.

PHP Fatal error:  Uncaught VersionControl_SVN_Exception: Command is not a known VersionControl_SVN command. in /usr/share/php/VersionControl/SVN.php on line 226
