### PR TITLE
Fixing a typo in a Diff command switch "summarize"

### DIFF
--- a/SVN/Command/Diff.php
+++ b/SVN/Command/Diff.php
@@ -249,7 +249,7 @@ class VersionControl_SVN_Command_Diff extends VersionControl_SVN_Command
                 'N', 'non-recursive',
                 'no-diff-deleted',
                 'notice-ancestry',
-                'summerize',
+                'summarize',
                 'force',
                 'xml',
             )


### PR DESCRIPTION
It was "summarize" before 58b842618bcff1a0d851540431d5f318fdd443b2

Bug was introduced in https://github.com/pear/VersionControl_SVN/commit/58b842618bcff1a0d851540431d5f318fdd443b2#L0L262
