### PR TITLE
Bug #20049: unset the xml switch instead of setting it to false.

### DIFF
--- a/VersionControl/SVN/Command.php
+++ b/VersionControl/SVN/Command.php
@@ -367,7 +367,7 @@ abstract class VersionControl_SVN_Command
         ) {
             $this->switches['xml'] = true;
         } else {
-            $this->switches['xml'] = false;
+            unset($this->switches['xml']);
         }
 
         $this->switches['non-interactive'] = true;


### PR DESCRIPTION
We should unset instead of setting it to false.
