### PR TITLE
Fix an error with missing required file (System.php)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     },
     "type": "library",
     "require": {
+        "pear/pear-core-minimal": "^1.10",
         "pear/pear_exception": "*@dev",
         "php": ">=5.3.0"
     },


### PR DESCRIPTION
Require the pear-core-minimal package to fix an error with missing System.php file when pulling in project through Composer.