### PR TITLE
Add the 'file-external' property to the svn status command parser

### DIFF
--- a/VersionControl/SVN/Parser/XML/Status.php
+++ b/VersionControl/SVN/Parser/XML/Status.php
@@ -77,7 +77,7 @@ class VersionControl_SVN_Parser_XML_Status
                             'quantifier' => '+',
                             'path' => array(
                                 'wc-status' => array(
-                                    'attribute' => array('item', 'revision', 'props'),
+                                    'attribute' => array('item', 'revision', 'props', 'file-external'),
                                     'path' => array(
                                         'commit' => array(
                                             'attribute' => array('revision'),


### PR DESCRIPTION
Svn status sets the property 'file-external'='true' for files that are externally defined in the repo.