### PR TITLE
fix php's escapeshellarg on windows

### DIFF
--- a/VersionControl/SVN/Command.php
+++ b/VersionControl/SVN/Command.php
@@ -550,6 +550,10 @@ abstract class VersionControl_SVN_Command
 
     /**
      * Escape a single value in accordance with CommandLineToArgV() for Windows
+     *
+     * @param string $value
+     * @return string
+     * @throws VersionControl_SVN_Exception If command failed.
      * @see https://docs.microsoft.com/en-us/previous-versions/17w5ykft(v=vs.85)
      */
     private function escapeshellarg($value)


### PR DESCRIPTION
On Windows function escapeshellargs naively strips special characters and replaces them **with spaces**. The resulting string is always safe for use with exec() etc, but the operation is not lossless - strings containing " or % will not be passed through to the child process correctly.

This patch fix execution subversion's win32-binary with "specific" arguments (exclamation in password for example).