### PR TITLE
Make code more friendly for autoloaders

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 composer install
-phpunit
+vendor/bin/phpunit

--- a/VersionControl/SVN/Command/Add.php
+++ b/VersionControl/SVN/Command/Add.php
@@ -93,7 +93,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * // Pass array of subcommands we need to factory
  * $svn = VersionControl_SVN::factory(array('add'), $options);

--- a/VersionControl/SVN/Command/Blame.php
+++ b/VersionControl/SVN/Command/Blame.php
@@ -91,7 +91,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * // Pass array of subcommands we need to factory
  * // Blame supports alternate names: blame, praise, annotate, ann

--- a/VersionControl/SVN/Command/Cat.php
+++ b/VersionControl/SVN/Command/Cat.php
@@ -90,7 +90,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * // Pass array of subcommands we need to factory
  * $svn = VersionControl_SVN::factory(array('cat'), $options);

--- a/VersionControl/SVN/Command/Checkout.php
+++ b/VersionControl/SVN/Command/Checkout.php
@@ -100,7 +100,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * // Pass array of subcommands we need to factory
  * $svn = VersionControl_SVN::factory(array('checkout'), $options);

--- a/VersionControl/SVN/Command/Commit.php
+++ b/VersionControl/SVN/Command/Commit.php
@@ -106,7 +106,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * // Pass array of subcommands we need to factory
  * $svn = VersionControl_SVN::factory(array('checkout'), $options);

--- a/VersionControl/SVN/Command/Copy.php
+++ b/VersionControl/SVN/Command/Copy.php
@@ -112,7 +112,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * // Pass array of subcommands we need to factory
  * $svn = VersionControl_SVN::factory(array('copy'), $options);

--- a/VersionControl/SVN/Command/Delete.php
+++ b/VersionControl/SVN/Command/Delete.php
@@ -106,7 +106,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * // Pass array of subcommands we need to factory
  * $svn = VersionControl_SVN::factory(array('delete'), $options);

--- a/VersionControl/SVN/Command/Diff.php
+++ b/VersionControl/SVN/Command/Diff.php
@@ -87,7 +87,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * $switches = array('r' => '5:8');
  * $args = array('svn://svn.example.com/repos/TestProj/trunk/example.php',
@@ -110,7 +110,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * $switches = array('r' => '5:8');
  * $args = array('svn://svn.example.com/repos/TestProj/trunk/example.php');
@@ -131,7 +131,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * $switches = array('r' => '5:8');
  * $args = array('svn://svn.example.com/repos/TestProj/trunk/example.php',

--- a/VersionControl/SVN/Command/Export.php
+++ b/VersionControl/SVN/Command/Export.php
@@ -79,7 +79,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * $switches = array('r' => 'HEAD');
  * $args = array('svn://svn.example.com/repos/TestProj/trunk',
@@ -102,7 +102,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * $args = array('/repos/TestProj/trunk',
  *               '/my/export/path/Test-Project-1.0');

--- a/VersionControl/SVN/Command/Import.php
+++ b/VersionControl/SVN/Command/Import.php
@@ -109,7 +109,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * // Pass array of subcommands we need to factory
  * $svn = VersionControl_SVN::factory(array('import'), $options);

--- a/VersionControl/SVN/Command/Info.php
+++ b/VersionControl/SVN/Command/Info.php
@@ -83,7 +83,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * // Pass array of subcommands we need to factory
  * $svn = VersionControl_SVN::factory(array('info'), $options);

--- a/VersionControl/SVN/Command/List.php
+++ b/VersionControl/SVN/Command/List.php
@@ -102,7 +102,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * // Pass array of subcommands we need to factory
  * $svn = VersionControl_SVN::factory(array('list'), $options);

--- a/VersionControl/SVN/Command/Log.php
+++ b/VersionControl/SVN/Command/Log.php
@@ -81,8 +81,8 @@ require_once 'VersionControl/SVN/Command.php';
  *  'incremental'   =>  true|false,
  *                      // gives output suitable for concatenation
  *  'xml'           =>  true|false,
- *                      // output in XML. Auto-set by fetchmodes VERSIONCONTROL_SVN_FETCHMODE_ASSOC,
- *                      // VERSIONCONTROL_SVN_FETCHMODE_XML and VERSIONCONTROL_SVN_FETCHMODE_OBJECT
+ *                      // output in XML. Auto-set by fetchmodes VersionControl_SVN::FETCHMODE_ASSOC,
+ *                      // VersionControl_SVN::FETCHMODE_XML and VersionControl_SVN::FETCHMODE_OBJECT
  *  'no-auth-cache' =>  true|false
  *                      // Do not cache authentication tokens
  *
@@ -100,7 +100,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_ASSOC);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_ASSOC);
  *
  * // Pass array of subcommands we need to factory
  * $svn = VersionControl_SVN::factory(array('log'), $options);

--- a/VersionControl/SVN/Command/Merge.php
+++ b/VersionControl/SVN/Command/Merge.php
@@ -85,7 +85,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * $args = array(
  *  'svn://svn.example.com/repos/TestProj/trunk/example.php@4',   // sourceurl1
@@ -109,7 +109,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * $args = array(
  *  '/path/to/working/copy/trunk/example.php@4',    // wcpath1
@@ -132,7 +132,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * $switches = array('r' => '5:8');
  * $args = array('svn://svn.example.com/repos/TestProj/trunk/example.php');

--- a/VersionControl/SVN/Command/Mkdir.php
+++ b/VersionControl/SVN/Command/Mkdir.php
@@ -112,7 +112,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * // Pass array of subcommands we need to factory
  * $svn = VersionControl_SVN::factory(array('mkdir'), $options);

--- a/VersionControl/SVN/Command/Move.php
+++ b/VersionControl/SVN/Command/Move.php
@@ -113,7 +113,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * // Pass array of subcommands we need to factory
  * $svn = VersionControl_SVN::factory(array('move'), $options);

--- a/VersionControl/SVN/Command/Propdel.php
+++ b/VersionControl/SVN/Command/Propdel.php
@@ -97,7 +97,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * // Pass array of subcommands we need to factory
  * $svn = VersionControl_SVN::factory(array('propdel'), $options);

--- a/VersionControl/SVN/Command/Propget.php
+++ b/VersionControl/SVN/Command/Propget.php
@@ -104,7 +104,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * // Pass array of subcommands we need to factory
  * $svn = VersionControl_SVN::factory(array('propget'), $options);

--- a/VersionControl/SVN/Command/Proplist.php
+++ b/VersionControl/SVN/Command/Proplist.php
@@ -99,7 +99,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * // Pass array of subcommands we need to factory
  * $svn = VersionControl_SVN::factory(array('proplist'), $options);

--- a/VersionControl/SVN/Command/Propset.php
+++ b/VersionControl/SVN/Command/Propset.php
@@ -131,7 +131,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * // Pass array of subcommands we need to factory
  * $svn = VersionControl_SVN::factory(array('propset'), $options);

--- a/VersionControl/SVN/Command/Resolved.php
+++ b/VersionControl/SVN/Command/Resolved.php
@@ -88,7 +88,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * // Pass array of subcommands we need to factory
  * $svn = VersionControl_SVN::factory(array('resolved'), $options);

--- a/VersionControl/SVN/Command/Revert.php
+++ b/VersionControl/SVN/Command/Revert.php
@@ -87,7 +87,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * // Pass array of subcommands we need to factory
  * $svn = VersionControl_SVN::factory(array('revert'), $options);

--- a/VersionControl/SVN/Command/Status.php
+++ b/VersionControl/SVN/Command/Status.php
@@ -159,7 +159,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * // Pass array of subcommands we need to factory
  * $svn = VersionControl_SVN::factory(array('status'), $options);

--- a/VersionControl/SVN/Command/Switch.php
+++ b/VersionControl/SVN/Command/Switch.php
@@ -75,7 +75,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * $switches = array('relocate' => 'true');
  * $args = array(

--- a/VersionControl/SVN/Command/Update.php
+++ b/VersionControl/SVN/Command/Update.php
@@ -81,7 +81,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * $switches = array('r' => '30');
  * $args = array('/path/to/working/copy');

--- a/VersionControl/SVN/Command/Upgrade.php
+++ b/VersionControl/SVN/Command/Upgrade.php
@@ -79,7 +79,7 @@ require_once 'VersionControl/SVN/Command.php';
  *
  * // Set up runtime options. Will be passed to all 
  * // subclasses.
- * $options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+ * $options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
  *
  * $switches = array('r' => '30');
  * $args = array('/path/to/working/copy');

--- a/VersionControl/SVN/Parser/XML.php
+++ b/VersionControl/SVN/Parser/XML.php
@@ -194,7 +194,7 @@ class VersionControl_SVN_Parser_XML
         if (isset($xmlPathConfig['config'])
             && 'string' === $xmlPathConfig['config']
         ) {
-            if (count($data) > 0) {
+            if (!empty($data)) {
                 $data = array_merge(
                     array('text' => self::getParsedString($reader, $xmlEntry)),
                     $data

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "autoload": {
         "psr-0": {
-            "VersionControl_SVN": "./"
+            "VersionControl_": "./"
         }
     },
     "description": "More info available on: http://pear.php.net/package/VersionControl_SVN",

--- a/docs/examples/example_tree.php
+++ b/docs/examples/example_tree.php
@@ -67,7 +67,7 @@ if (isset($_SERVER['PATH_INFO'])) {
 $cmd = '';
 $cmd = isset($_GET['cmd']) ? $_GET['cmd'] : 'list';
 
-$options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_ASSOC);
+$options = array('fetchmode' => VersionControl_SVN::FETCHMODE_ASSOC);
 $switches = array('R' => true);
 $args = array("{$base_url}{$base_add}");
 

--- a/docs/tutorials/VersionControl_SVN/VersionControl_SVN.pkg
+++ b/docs/tutorials/VersionControl_SVN/VersionControl_SVN.pkg
@@ -60,7 +60,7 @@ require_once 'VersionControl/SVN.php';
 $svnstack = &PEAR_ErrorStack::singleton('VersionControl_SVN');
 
 // Set up runtime options. 
-$options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_ARRAY);
+$options = array('fetchmode' => VersionControl_SVN::FETCHMODE_ARRAY);
 // Request list class from factory
 $svn = VersionControl_SVN::factory('list', $options);
 
@@ -72,7 +72,7 @@ $args = array('svn://svn.example.com/repos/TestProject');
 if ($output = $svn->run($args, $switches)) {
     print_r($output);
 } else {
-    if (count($errs = $svnstack->getErrors())) { 
+    if (!empty($errs = $svnstack->getErrors())) {
         foreach ($errs as $err) {
             echo '<br />'.$err['message']."<br />\n";
             echo "Command used: " . $err['params']['cmd'];
@@ -158,7 +158,7 @@ require_once 'VersionControl/SVN.php';
 $svnstack = &PEAR_ErrorStack::singleton('VersionControl_SVN');
 
 // Set up runtime options. 
-$options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_ARRAY);
+$options = array('fetchmode' => VersionControl_SVN::FETCHMODE_ARRAY);
 
 // Request list class from factory
 $svn = VersionControl_SVN::factory('list', $options);
@@ -171,7 +171,7 @@ $args = array('svn://svn.example.com/repos/TestProject');
 if ($output = $svn->run($args, $switches)) {
     print_r($output);
 } else {
-    if (count($errs = $svnstack->getErrors())) { 
+    if (!empty($errs = $svnstack->getErrors())) {
         foreach ($errs as $err) {
             echo '<br />'.$err['message']."<br />\n";
             echo "Command used: " . $err['params']['cmd'];
@@ -196,7 +196,7 @@ require_once 'VersionControl/SVN.php';
 $svnstack = &PEAR_ErrorStack::singleton('VersionControl_SVN');
 
 // Set up runtime options. 
-$options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_RAW);
+$options = array('fetchmode' => VersionControl_SVN::FETCHMODE_RAW);
 
 // METHOD ONE: Lowest Overhead
 // Create svn object with subcommands we need listed out individually

--- a/tests/diff.phpt
+++ b/tests/diff.phpt
@@ -3,12 +3,12 @@ test diff xml
 --SKIPIF--
 --FILE--
 <?php
-require_once dirname(__FILE__) . '/setup.php.inc';
+require_once __DIR__ . '/setup.php.inc';
 
 $changeset = '325013';
 $url = 'http://svn.php.net/repository/pear';
 
-$options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_ASSOC);
+$options = array('fetchmode' => VersionControl_SVN::FETCHMODE_ASSOC);
 $switches = array('summarize' => true, 'c' => $changeset);
 
 $svn = VersionControl_SVN::factory(array('diff'), $options);

--- a/tests/list.phpt
+++ b/tests/list.phpt
@@ -3,12 +3,12 @@ test list xml
 --SKIPIF--
 --FILE--
 <?php
-require_once dirname(__FILE__) . '/setup.php.inc';
+require_once __DIR__ . '/setup.php.inc';
 
 $changeset = '325013';
 $url = 'https://github.com/pear/VersionControl_SVN/tags/0.5.0/docs';
 
-$options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_ASSOC);
+$options = array('fetchmode' => VersionControl_SVN::FETCHMODE_ASSOC);
 $switches = array();
 
 $svn = VersionControl_SVN::factory(array('list'), $options);

--- a/tests/log.phpt
+++ b/tests/log.phpt
@@ -3,12 +3,12 @@ test log xml
 --SKIPIF--
 --FILE--
 <?php
-require_once dirname(__FILE__) . '/setup.php.inc';
+require_once __DIR__ . '/setup.php.inc';
 
 $changeset = '325013';
 $url = 'http://svn.php.net/repository/pear';
 
-$options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_ASSOC);
+$options = array('fetchmode' => VersionControl_SVN::FETCHMODE_ASSOC);
 $switches = array('c' => $changeset);
 
 $svn = VersionControl_SVN::factory(array('log'), $options);

--- a/tests/phpt_test.php.inc
+++ b/tests/phpt_test.php.inc
@@ -41,7 +41,7 @@ class PEAR_PHPTest
 
     function assertNoErrors($message, $trace = null)
     {
-        if (count($this->_errors) == 0) {
+        if (empty($this->_errors)) {
             return true;
         }
         if ($trace === null) {
@@ -105,7 +105,7 @@ class PEAR_PHPTest
             }
             echo "message: \"$err[message]\"\n";
         }
-        if (count($this->_errors)) {
+        if (!empty($this->_errors)) {
             if (!$failed) {
                 if ($trace === null) {
                     $trace = debug_backtrace();

--- a/tests/propget-recursive.phpt
+++ b/tests/propget-recursive.phpt
@@ -8,7 +8,7 @@ require_once __DIR__ . '/setup.php.inc';
 $changeset = '334899';
 $url = 'http://svn.php.net/repository/pear/pearbot/tags/pearbot_0_1/';
 
-$options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_ASSOC);
+$options = array('fetchmode' => VersionControl_SVN::FETCHMODE_ASSOC);
 $switches = array('recursive' => true, 'r' => $changeset);
 
 $svn = VersionControl_Svn::factory(array('propget'), $options);

--- a/tests/propget.phpt
+++ b/tests/propget.phpt
@@ -8,7 +8,7 @@ require_once __DIR__ . '/setup.php.inc';
 $changeset = '334899';
 $url = 'http://svn.php.net/repository/pear/pearbot/tags/pearbot_0_1/PEARbot.php';
 
-$options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_ASSOC);
+$options = array('fetchmode' => VersionControl_SVN::FETCHMODE_ASSOC);
 $switches = array('r' => $changeset);
 
 $svn = VersionControl_Svn::factory(array('propget'), $options);

--- a/tests/proplist-recursive.phpt
+++ b/tests/proplist-recursive.phpt
@@ -8,7 +8,7 @@ require_once __DIR__ . '/setup.php.inc';
 $changeset = '334899';
 $url = 'http://svn.php.net/repository/pear/pearbot/tags/pearbot_0_1/';
 
-$options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_ASSOC);
+$options = array('fetchmode' => VersionControl_SVN::FETCHMODE_ASSOC);
 $switches = array('recursive' => true, 'r' => $changeset);
 
 $svn = VersionControl_Svn::factory(array('proplist'), $options);

--- a/tests/proplist.phpt
+++ b/tests/proplist.phpt
@@ -8,7 +8,7 @@ require_once __DIR__ . '/setup.php.inc';
 $changeset = '334899';
 $url = 'http://svn.php.net/repository/pear/pearbot/tags/pearbot_0_1/PEARbot.php';
 
-$options = array('fetchmode' => VERSIONCONTROL_SVN_FETCHMODE_ASSOC);
+$options = array('fetchmode' => VersionControl_SVN::FETCHMODE_ASSOC);
 $switches = array('r' => $changeset);
 
 $svn = VersionControl_Svn::factory(array('proplist'), $options);

--- a/tests/resetxml_19910.phpt
+++ b/tests/resetxml_19910.phpt
@@ -3,7 +3,7 @@ test if xml switch is reset between commands (see bug #19910)
 --SKIPIF--
 --FILE--
 <?php
-require_once dirname(__FILE__) . '/setup.php.inc';
+require_once __DIR__ . '/setup.php.inc';
 
 $changeset = '325013';
 $url = 'https://github.com/pear/VersionControl_SVN/tags/0.5.0';
@@ -12,11 +12,11 @@ $switches = array('c' => $changeset);
 
 $svn = VersionControl_SVN::factory(array('log'));
 
-$svn->log->fetchmode = VERSIONCONTROL_SVN_FETCHMODE_XML;
+$svn->log->fetchmode = VersionControl_SVN::FETCHMODE_XML;
 $result = $svn->log->run(array($url));
 var_export($result);
 
-$svn->log->fetchmode = VERSIONCONTROL_SVN_FETCHMODE_RAW;
+$svn->log->fetchmode = VersionControl_SVN::FETCHMODE_RAW;
 $result = $svn->log->run(array($url));
 var_export($result);
 

--- a/tests/setup.php.inc
+++ b/tests/setup.php.inc
@@ -1,3 +1,4 @@
 <?php
 set_include_path("..:" . get_include_path());
-require_once dirname(dirname(__FILE__)) . '/VersionControl/SVN.php';
+putenv('LANG=en_US');
+require_once dirname(__DIR__) . '/vendor/autoload.php';

--- a/tests/upgrade.phpt
+++ b/tests/upgrade.phpt
@@ -3,7 +3,7 @@ test upgrade xml
 --SKIPIF--
 --FILE--
 <?php
-require_once dirname(__FILE__) . '/setup.php.inc';
+require_once __DIR__ . '/setup.php.inc';
 
 $svn = VersionControl_SVN::factory(array('upgrade'));
 $result = array();


### PR DESCRIPTION
* fix composer autoloader
* replace lookup subclasses with class_exists
* move global constants to VersionControl_SVN::class

see https://github.com/phingofficial/task-svn/issues/2