### PR TITLE
Fix issue: Could not find parser for command output: "svn update"

### DIFF
--- a/VersionControl/SVN/Command.php
+++ b/VersionControl/SVN/Command.php
@@ -534,11 +534,6 @@ abstract class VersionControl_SVN_Command
                         return (object) $parsedData;
                     }
                     return $parsedData;
-                } else {
-                    throw new VersionControl_SVN_Exception(sprintf(
-                        "Could not find parser for command output: '%s'",
-                        $this->commandName
-                    ), VersionControl_SVN_Exception::ERROR);
                 }
                 break;
             case VersionControl_SVN::FETCHMODE_RAW:


### PR DESCRIPTION
Since 02dbae4ea53edba2cfae2de62430c613a4daf7d1 some commands thrown "unexpected" VersionControl_SVN_Exception. This commit rollback some changes for fix it.